### PR TITLE
Improve the showTransferHandler function - prevent unnecessary request when revoking

### DIFF
--- a/src/app/components/elements/OutgoingDelegations.jsx
+++ b/src/app/components/elements/OutgoingDelegations.jsx
@@ -289,11 +289,23 @@ class OutgoingDelegations extends React.Component {
             const accountName = account.get('name');
 
             const refetchCB = () => {
-                vestingDelegationsLoading(true);
-                getVestingDelegations(accountName, (err, res) => {
-                    setVestingDelegations(res);
-                    vestingDelegationsLoading(false);
-                });
+                try {
+                    const { auxiliaryData, currentPage } = this.state;
+                    vestingDelegationsLoading(true);
+                    const data = auxiliaryData.filter(
+                        item => item.delegatee !== d
+                    );
+                    if (
+                        currentPage !== 1 &&
+                        d === auxiliaryData[auxiliaryData.length - 1].delegatee
+                    ) {
+                        this.setState({ currentPage: currentPage - 1 });
+                    }
+                    this.setState({ auxiliaryData: data });
+                    this.updateVestingDelegations(data);
+                } catch (error) {
+                    console.log(error);
+                }
             };
             revokeDelegation(accountName, d, refetchCB);
         };


### PR DESCRIPTION
**The showTransferHandler function has been modified.**

- Previous behavior: It involved making a new request to the node using the getVestingDelegations function every time a delegation was revoked. Therefore, every time a delegation was revoked, an attempt was made to obtain the updated list of accounts to which the delegation had been made. However, this method is not practical when delegations have been made to more than 1000 accounts and multiple requests need to be made.
- Current behavior: After revoking the delegation, the respective account will be removed from the array where all delegated accounts are stored. This approach avoids making additional requests to the node.