### PR TITLE
Validate minimum delegated quantity

### DIFF
--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -256,7 +256,11 @@ class TransferForm extends Component {
                                     ? tt(
                                           'transfer_jsx.use_only_3_digits_of_precison'
                                       )
-                                    : null,
+                                    : (toDelegate && (values.amount < 1 && values.amount > 0))
+                                        ? tt(
+                                            'transfer_jsx.minimum_required_delegation_amount'
+                                        )
+                                        : null,
                 asset: props.toVesting
                     ? null
                     : !values.asset

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -885,6 +885,7 @@
         "amount_is_in_form": "Amount is in the form 99999.999",
         "insufficient_funds": "Insufficient funds",
         "use_only_3_digits_of_precison": "Use only 3 digits of precison",
+        "minimum_required_delegation_amount": "The minimum required delegation amount is 1.000 SP",
         "use_only_6_digits_of_precision": "Use only 6 digits of precision",
         "send_to_account": "Send to account",
         "asset": "Asset",


### PR DESCRIPTION
A validation has been added so that when the user wants to delegate less than 1 steem, it prevents them from proceeding and instead displays a message indicating that 'The minimum required delegation amount is 1.000 SP