### PR TITLE
fix(proposals): correctly retrieve logged-in user votes on proposals 

### DIFF
--- a/src/app/components/modules/ProposalList/ProposalList.jsx
+++ b/src/app/components/modules/ProposalList/ProposalList.jsx
@@ -65,72 +65,68 @@ class ProposalList extends React.Component {
         });
     }
 
-    fetchConfig() {
-        if (REFUND_ACCOUNTS.length > 0) {
-            api.getAccountsAsync(REFUND_ACCOUNTS)
-                .then(res => {
-                    if (res && res.length > 0 && res[0].sbd_balance) {
-                        const rawBalance = res[0].sbd_balance;
-                        const numericPart = rawBalance.split(' ')[0];
-                        this.setState({
-                            daoTreasury: numberWithCommas(numericPart),
-                            dailyBudget: numberWithCommas(
-                                `${(parseFloat(numericPart) / 100).toFixed(3)}`
-                            ),
-                        });
-                    }
-                })
-                .catch(err => console.log(err));
+    async fetchConfig() {
+        try {
+            if (REFUND_ACCOUNTS.length > 0) {
+                const res = await api.getAccountsAsync(REFUND_ACCOUNTS);
+                if (res && res.length > 0 && res[0].sbd_balance) {
+                    const rawBalance = res[0].sbd_balance;
+                    const numericPart = rawBalance.split(' ')[0];
+                    this.setState({
+                        daoTreasury: numberWithCommas(numericPart),
+                        dailyBudget: numberWithCommas(
+                            `${(parseFloat(numericPart) / 100).toFixed(3)}`
+                        ),
+                    });
+                }
+            }
+        } catch (err) {
+            console.error('DEBUG_LOG: Error in fetchConfig:', err);
         }
     }
 
-    fetchProposals() {
-        api.listProposalsAsync(
-            [-1, 0],
-            1000,
-            'by_total_votes',
-            'descending',
-            'active'
-        )
-            .then(proposals => {
-                try {
-                    if (!Array.isArray(proposals)) {
-                        console.log(
-                            'DEBUG_LOG: Error - Proposals is not an array',
-                            proposals
-                        ); // DEBUG_LOG
-                        return;
-                    }
-                    const { dailyBudget } = this.state;
-                    let budget = parseFloat(dailyBudget.replace(/,/g, ''));
-                    const selectedProposalIds = [];
-                    for (let i = 0; i < proposals.length; i++) {
-                        const proposal = proposals[i];
-                        const payStr = proposal.daily_pay
-                            .replace(' SBD', '')
-                            .replace(/,/g, '');
-                        const pay = parseFloat(payStr);
-                        if (proposal.daily_pay) {
-                            if (budget - pay >= 0) {
-                                budget -= pay;
-                                selectedProposalIds.push(proposal.id);
-                            } else if (budget > 0 && budget - pay < 0) {
-                                budget -= pay;
-                                selectedProposalIds.push(proposal.id);
-                                break;
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                    this.props.setPaidProposals(selectedProposalIds);
-                } catch (error) {
-                    console.error('DEBUG_LOG: Error in proposals:', error); // DEBUG_LOG
+
+    async fetchProposals() {
+        try {
+            const proposals = await api.listProposalsAsync(
+                [-1, 0],
+                1000,
+                'by_total_votes',
+                'descending',
+                'active'
+            );
+
+            if (!Array.isArray(proposals)) {
+                console.log(
+                    'DEBUG_LOG: Error - Proposals is not an array',
+                    proposals
+                );
+                return;
+            }
+
+            const { dailyBudget } = this.state;
+            let budget = parseFloat(dailyBudget.replace(/,/g, ''));
+            const selectedProposalIds = [];
+
+            for (let proposal of proposals) {
+                const pay = parseFloat(
+                    proposal.daily_pay.replace(' SBD', '').replace(/,/g, '')
+                );
+                if (budget - pay >= 0) {
+                    budget -= pay;
+                    selectedProposalIds.push(proposal.id);
+                } else if (budget > 0) {
+                    selectedProposalIds.push(proposal.id);
+                    break;
+                } else {
+                    break;
                 }
-            })
-            .catch(err => {
-                console.error('DEBUG_LOG: Error fetching proposals:', err); // DEBUG_LOG
-            });
+            }
+
+            this.props.setPaidProposals(selectedProposalIds);
+        } catch (err) {
+            console.error('DEBUG_LOG: Error fetching proposals:', err);
+        }
     }
 
     render() {


### PR DESCRIPTION
### Context
This wallet project retains the original implementation from Steemit for retrieving proposal votes. 

### Root Cause
The existing implementation relied on the list_proposal_votes API method with the order=by_proposal_voter parameter. This approach is not optimal for retrieving the proposals voted on by a specific account, as it requires scanning all votes across all proposals to identify which ones were cast by the target account. Under high load or when too many sequential requests were made, this strategy could lead to performance issues or incomplete results from the API.

### Reference to the legacy logic:

[Current wallet code](https://github.com/steemit/wallet/blob/master/src/app/redux/ProposalSaga.js#L56)

[Steemit reference code](https://github.com/steemit/wallet/blob/5450d5b047c9a20d8bc89caae3bc6bd4a954d22d/src/app/redux/ProposalSaga.js#L57)

### Changes Implemented
1. Improved Vote Fetching Strategy

- The code now uses order=by_voter_proposal when querying the list_proposal_votes method.

- This allows retrieving all votes by a given account efficiently: votes from the target account appear first in the response, and parsing can stop as soon as another account appears.

- This change significantly reduces the number of API calls required and avoids the issues observed with the previous approach.

2. Vote Refresh on Login Events

- The system now detects when a user logs in while on the proposals page and immediately fetches the proposals that account has voted on.

- If a user logs out and logs back in with a different account, the vote list is refreshed accordingly.

### Result
The updated implementation ensures that an account’s votes are reliably fetched with fewer API calls and better performance, even when login actions occur dynamically on the proposals page.